### PR TITLE
Misc updates to make it run with latest version of keras and support for conversion to tensorflow frozen model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 env
+env2
 demo/img
 __pycache__
 .vscode
 data
 training_and_testing/300W_*
+converted-models

--- a/README.md
+++ b/README.md
@@ -191,7 +191,14 @@ cd demo
 sh run_demo_FSANET_ssd.sh
 ```
 
+### 4. Conversion to tensorflow frozen graph
 
+```bash
+cd training_and_testing
+python keras_to_tf.py --trained-model-dir-path ../pre-trained/300W_LP_models/fsanet_var_capsule_3_16_2_21_5 --output-dir-path <your_output_dir>
+```
+
+Above command will generate the tensorflow frozen graph in <your_output_dir>/converted-models/tf/fsanet_var_capsule_3_16_2_21_5.pb
 
 ### Modules explanation:
 

--- a/lib/FSANET_model.py
+++ b/lib/FSANET_model.py
@@ -81,6 +81,9 @@ class SSRLayer(Layer):
 
         return pred
 
+    def compute_output_shape(self, input_shape):
+        return (input_shape[0], 3)
+
     def get_config(self):
         config = {
             's1': self.s1,

--- a/lib/FSANET_model.py
+++ b/lib/FSANET_model.py
@@ -27,6 +27,8 @@ from .capsulelayers import MatMulLayer
 
 from .loupe_keras import NetVLAD
 
+from .utils import register_keras_custom_object
+
 sys.setrecursionlimit(2 ** 20)
 np.random.seed(2 ** 10)
 
@@ -35,13 +37,15 @@ np.random.seed(2 ** 10)
 # can be converted to various other formats. Usage of Lambda layers prevent the convertion
 # and the optimizations by the underlying math engine (tensorflow in this case)
 
+@register_keras_custom_object
 class SSRLayer(Layer):
     def __init__(self, s1, s2, s3, lambda_d, **kwargs):
-        super(SSRLayer, self).__init__(trainable=False, **kwargs)
+        super(SSRLayer, self).__init__(**kwargs)
         self.s1 = s1
         self.s2 = s2
         self.s3 = s3
         self.lambda_d = lambda_d
+        self.trainable = False
 
     def call(self, inputs):
         x = inputs
@@ -88,7 +92,7 @@ class SSRLayer(Layer):
         base_config = super(SSRLayer, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
-
+@register_keras_custom_object
 class FeatSliceLayer(Layer):
     def __init__(self, start_index, end_index,  **kwargs):
         super(FeatSliceLayer, self).__init__(**kwargs)
@@ -110,6 +114,7 @@ class FeatSliceLayer(Layer):
         base_config = super(FeatSliceLayer, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
+@register_keras_custom_object
 class MomentsLayer(Layer):
     def __init__(self, **kwargs):
         super(MomentsLayer,self).__init__(**kwargs)
@@ -122,6 +127,7 @@ class MomentsLayer(Layer):
     def compute_output_shape(self, input_shape):
         return (input_shape[0], input_shape[-1])
 
+@register_keras_custom_object
 class MatrixMultiplyLayer(Layer):
     def __init__(self, **kwargs):
         super(MatrixMultiplyLayer,self).__init__(**kwargs)
@@ -137,6 +143,7 @@ class MatrixMultiplyLayer(Layer):
     def compute_output_shape(self, input_shapes):        
         return (input_shapes[0][0],input_shapes[0][1], input_shapes[1][-1])
 
+@register_keras_custom_object
 class MatrixNormLayer(Layer):
     def __init__(self, tile_count,  **kwargs):
         super(MatrixNormLayer,self).__init__(**kwargs)
@@ -158,6 +165,7 @@ class MatrixNormLayer(Layer):
         base_config = super(MatrixNormLayer, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
+@register_keras_custom_object
 class PrimCapsLayer(Layer):
     def __init__(self, **kwargs):
         super(PrimCapsLayer,self).__init__(**kwargs)
@@ -170,6 +178,7 @@ class PrimCapsLayer(Layer):
     def compute_output_shape(self, input_shapes):                
         return input_shapes[-1]
 
+@register_keras_custom_object
 class AggregatedFeatureExtractionLayer(Layer):
     def __init__(self, num_capsule,  **kwargs):
         super(AggregatedFeatureExtractionLayer,self).__init__(**kwargs)

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,0 +1,1 @@
+from .FSANET_model import *

--- a/lib/capsulelayers.py
+++ b/lib/capsulelayers.py
@@ -1,75 +1,22 @@
 """
+Original code taken from Author: Xifeng Guo, E-mail: `guoxifeng1990@163.com`, Github: `https://github.com/XifengGuo/CapsNet-Keras`
+and adjusted for the needs of this project.
+
 Some key layers used for constructing a Capsule Network. These layers can used to construct CapsNet on other dataset, 
 not just on MNIST.
+
 *NOTE*: some functions can be implemented in multiple ways, I keep all of them. You can try them for yourself just by
 uncommenting them and commenting their counterparts.
 
 Author: Xifeng Guo, E-mail: `guoxifeng1990@163.com`, Github: `https://github.com/XifengGuo/CapsNet-Keras`
 """
 
-import keras.backend as K
-import tensorflow as tf
-from keras import initializers, layers
 import sys
+import tensorflow as tf
 
-class Length(layers.Layer):
-    """
-    Compute the length of vectors. This is used to compute a Tensor that has the same shape with y_true in margin_loss.
-    Using this layer as model's output can directly predict labels by using `y_pred = np.argmax(model.predict(x), 1)`
-    inputs: shape=[None, num_vectors, dim_vector]
-    output: shape=[None, num_vectors]
-    """
-    def call(self, inputs, **kwargs):
-        return K.sqrt(K.sum(K.square(inputs), -1))
-
-    def compute_output_shape(self, input_shape):
-        return input_shape[:-1]
-
-    def get_config(self):
-        config = super(Length, self).get_config()
-        return config
-
-
-class Mask(layers.Layer):
-    """
-    Mask a Tensor with shape=[None, num_capsule, dim_vector] either by the capsule with max length or by an additional 
-    input mask. Except the max-length capsule (or specified capsule), all vectors are masked to zeros. Then flatten the
-    masked Tensor.
-    For example:
-        ```
-        x = keras.layers.Input(shape=[8, 3, 2])  # batch_size=8, each sample contains 3 capsules with dim_vector=2
-        y = keras.layers.Input(shape=[8, 3])  # True labels. 8 samples, 3 classes, one-hot coding.
-        out = Mask()(x)  # out.shape=[8, 6]
-        # or
-        out2 = Mask()([x, y])  # out2.shape=[8,6]. Masked with true labels y. Of course y can also be manipulated.
-        ```
-    """
-    def call(self, inputs, **kwargs):
-        if type(inputs) is list:  # true label is provided with shape = [None, n_classes], i.e. one-hot code.
-            assert len(inputs) == 2
-            inputs, mask = inputs
-        else:  # if no true label, mask by the max length of capsules. Mainly used for prediction
-            # compute lengths of capsules
-            x = K.sqrt(K.sum(K.square(inputs), -1))
-            # generate the mask which is a one-hot code.
-            # mask.shape=[None, n_classes]=[None, num_capsule]
-            mask = K.one_hot(indices=K.argmax(x, 1), num_classes=x.get_shape().as_list()[1])
-
-        # inputs.shape=[None, num_capsule, dim_capsule]
-        # mask.shape=[None, num_capsule]
-        # masked.shape=[None, num_capsule * dim_capsule]
-        masked = K.batch_flatten(inputs * K.expand_dims(mask, -1))
-        return masked
-
-    def compute_output_shape(self, input_shape):
-        if type(input_shape[0]) is tuple:  # true label provided
-            return tuple([None, input_shape[0][1] * input_shape[0][2]])
-        else:  # no true label provided
-            return tuple([None, input_shape[1] * input_shape[2]])
-
-    def get_config(self):
-        config = super(Mask, self).get_config()
-        return config
+import keras.backend as K
+from keras import initializers
+from keras.layers import Layer
 
 
 def squash(vectors, axis=-1):
@@ -80,31 +27,23 @@ def squash(vectors, axis=-1):
     :return: a Tensor with same shape as input vectors
     """
     s_squared_norm = K.sum(K.square(vectors), axis, keepdims=True)
-    scale = s_squared_norm / (1 + s_squared_norm) / K.sqrt(s_squared_norm + K.epsilon())
+    scale = s_squared_norm / (1 + s_squared_norm) / \
+        K.sqrt(s_squared_norm + K.epsilon())
     return scale * vectors
 
-def contrast_squash(vectors, axis=-1):
 
-    # contrast_de = K.mean(vectors, axis, keepdims=True)
-    # s_squared_norm = K.sum(K.square(vectors), axis, keepdims=True)
-    # scale = 1 / (1 - contrast_de*0.9)
-    # dim = K.shape(vectors)[-1]
-    num = K.shape(vectors)[1]
-    # vec_de = 1-0.9*K.tile(K.mean(vectors,axis=-1,keepdims=True),(1,1,dim))
-    vec_de = 1-0.9*K.tile(K.mean(vectors,axis=1,keepdims=True),(1,num,1))
-    return vectors/vec_de
-
-class CapsuleLayer(layers.Layer):
+class CapsuleLayer(Layer):
     """
     The capsule layer. It is similar to Dense layer. Dense layer has `in_num` inputs, each is a scalar, the output of the 
     neuron from the former layer, and it has `out_num` output neurons. CapsuleLayer just expand the output of the neuron
     from scalar to vector. So its input shape = [None, input_num_capsule, input_dim_capsule] and output shape = \
     [None, num_capsule, dim_capsule]. For Dense Layer, input_dim_capsule = dim_capsule = 1.
-    
+
     :param num_capsule: number of capsules in this layer
     :param dim_capsule: dimension of the output vectors of the capsules in this layer
     :param routings: number of iterations for the routing algorithm
     """
+
     def __init__(self, num_capsule, dim_capsule, routings=3,
                  kernel_initializer='glorot_uniform',
                  **kwargs):
@@ -115,7 +54,8 @@ class CapsuleLayer(layers.Layer):
         self.kernel_initializer = initializers.get(kernel_initializer)
 
     def build(self, input_shape):
-        assert len(input_shape) >= 3, "The input Tensor should have shape=[None, input_num_capsule, input_dim_capsule]"
+        assert len(
+            input_shape) >= 3, "The input Tensor should have shape=[None, input_num_capsule, input_dim_capsule]"
         self.input_num_capsule = input_shape[1]
         self.input_dim_capsule = input_shape[2]
 
@@ -142,12 +82,14 @@ class CapsuleLayer(layers.Layer):
         # Regard the first two dimensions as `batch` dimension,
         # then matmul: [input_dim_capsule] x [dim_capsule, input_dim_capsule]^T -> [dim_capsule].
         # inputs_hat.shape = [None, num_capsule, input_num_capsule, dim_capsule]
-        inputs_hat = K.map_fn(lambda x: K.batch_dot(x, self.W, [2, 3]), elems=inputs_tiled)
+        inputs_hat = K.map_fn(lambda x: K.batch_dot(
+            x, self.W, [2, 3]), elems=inputs_tiled)
 
         # Begin: Routing algorithm ---------------------------------------------------------------------#
         # The prior for coupling coefficient, initialized as zeros.
         # b.shape = [None, self.num_capsule, self.input_num_capsule].
-        b = tf.zeros(shape=[K.shape(inputs_hat)[0], self.num_capsule, self.input_num_capsule])
+        b = tf.zeros(shape=[K.shape(inputs_hat)[0],
+                            self.num_capsule, self.input_num_capsule])
         output_list = []
         assert self.routings > 0, 'The routings should be > 0.'
         for i in range(self.routings):
@@ -159,7 +101,8 @@ class CapsuleLayer(layers.Layer):
             # The first two dimensions as `batch` dimension,
             # then matmal: [input_num_capsule] x [input_num_capsule, dim_capsule] -> [dim_capsule].
             # outputs.shape=[None, num_capsule, dim_capsule]
-            outputs = squash(K.batch_dot(c, inputs_hat, [2, 2]))  # [None, 10, 16]
+            # [None, 10, 16]
+            outputs = squash(K.batch_dot(c, inputs_hat, [2, 2]))
             # output_list.append(K.expand_dims(outputs,axis=-1))
             if i < self.routings - 1:
                 # outputs.shape =  [None, num_capsule, dim_capsule]
@@ -186,171 +129,7 @@ class CapsuleLayer(layers.Layer):
         return dict(list(base_config.items()) + list(config.items()))
 
 
-
-class CapsProjectionW(layers.Layer):
-    """
-    The capsule layer. It is similar to Dense layer. Dense layer has `in_num` inputs, each is a scalar, the output of the 
-    neuron from the former layer, and it has `out_num` output neurons. CapsuleLayer just expand the output of the neuron
-    from scalar to vector. So its input shape = [None, input_num_capsule, input_dim_capsule] and output shape = \
-    [None, num_capsule, dim_capsule]. For Dense Layer, input_dim_capsule = dim_capsule = 1.
-    
-    :param num_capsule: number of capsules in this layer
-    :param dim_capsule: dimension of the output vectors of the capsules in this layer
-    :param routings: number of iterations for the routing algorithm
-    """
-    def __init__(self, dim_capsule,
-                 kernel_initializer='glorot_uniform',
-                 **kwargs):
-        super(CapsProjectionW, self).__init__(**kwargs)
-        self.dim_capsule = dim_capsule
-        self.kernel_initializer = initializers.get(kernel_initializer)
-
-    def build(self, input_shape):
-        assert len(input_shape) >= 3, "The input Tensor should have shape=[None, input_num_capsule, input_dim_capsule]"
-        self.input_num_capsule = input_shape[1]
-        self.input_dim_capsule = input_shape[2]
-
-        # Transform matrix
-        self.W = self.add_weight(shape=[self.input_num_capsule,
-                                        self.dim_capsule, self.input_dim_capsule],
-                                 initializer=self.kernel_initializer,
-                                 name='W')
-
-        self.built = True
-
-    def call(self, inputs, training=None):
-        # inputs.shape=[None, input_num_capsule, input_dim_capsule]
-        
-        # Compute `inputs * W` by scanning inputs_tiled on dimension 0.
-        # x.shape=[input_num_capsule, input_dim_capsule]
-        # W.shape=[input_num_capsule, dim_capsule, input_dim_capsule]
-        # Regard the first two dimensions as `batch` dimension,
-        # then matmul: [input_dim_capsule] x [dim_capsule, input_dim_capsule]^T -> [dim_capsule].
-        # inputs_hat.shape = [None, input_num_capsule, dim_capsule]
-        outputs = K.map_fn(lambda x: K.batch_dot(x, self.W, [1, 2]), elems=inputs)
-
-        
-        return outputs
-
-    def compute_output_shape(self, input_shape):
-        return tuple([None, self.input_num_capsule, self.dim_capsule])
-        # return tuple([None, self.num_capsule, self.dim_capsule, self.routings])
-
-    def get_config(self):
-        config = {
-            'dim_capsule': self.dim_capsule,
-        }
-        base_config = super(CapsProjectionW, self).get_config()
-        return dict(list(base_config.items()) + list(config.items()))
-
-
-
-
-
-
-
-
-
-class CapsuleLayer_T(layers.Layer):
-    """
-    The capsule layer. It is similar to Dense layer. Dense layer has `in_num` inputs, each is a scalar, the output of the 
-    neuron from the former layer, and it has `out_num` output neurons. CapsuleLayer just expand the output of the neuron
-    from scalar to vector. So its input shape = [None, input_num_capsule, input_dim_capsule] and output shape = \
-    [None, num_capsule, dim_capsule]. For Dense Layer, input_dim_capsule = dim_capsule = 1.
-    
-    :param num_capsule: number of capsules in this layer
-    :param dim_capsule: dimension of the output vectors of the capsules in this layer
-    :param routings: number of iterations for the routing algorithm
-    """
-    def __init__(self, num_capsule, dim_capsule, routings=3,
-                 kernel_initializer='glorot_uniform',
-                 **kwargs):
-        super(CapsuleLayer_T, self).__init__(**kwargs)
-        self.num_capsule = num_capsule
-        self.dim_capsule = dim_capsule
-        self.routings = routings
-        self.kernel_initializer = initializers.get(kernel_initializer)
-
-    def build(self, input_shape):
-        assert len(input_shape) >= 3, "The input Tensor should have shape=[None, input_num_capsule, input_dim_capsule]"
-        self.input_num_capsule = input_shape[1]
-        self.input_dim_capsule = input_shape[2]
-
-        # # Transform matrix
-        self.W = self.add_weight(shape=[self.num_capsule, self.input_num_capsule,
-                                        self.dim_capsule, self.input_dim_capsule],
-                                 initializer=self.kernel_initializer,
-                                 name='W')
-        self.T = self.add_weight(shape=[1,self.num_capsule,1],
-                                 initializer=self.kernel_initializer,
-                                 name='T')
-        self.built = True
-
-    def call(self, inputs, training=None):
-        # inputs.shape=[None, input_num_capsule, input_dim_capsule]
-        # inputs_expand.shape=[None, 1, input_num_capsule, input_dim_capsule]
-        inputs_expand = K.expand_dims(inputs, 1)
-
-        # Replicate num_capsule dimension to prepare being multiplied by W
-        # inputs_tiled.shape=[None, num_capsule, input_num_capsule, input_dim_capsule]
-        inputs_tiled = K.tile(inputs_expand, [1, self.num_capsule, 1, 1])
-
-        # Compute `inputs * W` by scanning inputs_tiled on dimension 0.
-        # x.shape=[num_capsule, input_num_capsule, input_dim_capsule]
-        # W.shape=[num_capsule, input_num_capsule, dim_capsule, input_dim_capsule]
-        # Regard the first two dimensions as `batch` dimension,
-        # then matmul: [input_dim_capsule] x [dim_capsule, input_dim_capsule]^T -> [dim_capsule].
-        # inputs_hat.shape = [None, num_capsule, input_num_capsule, dim_capsule]
-        inputs_hat = K.map_fn(lambda x: K.batch_dot(x, self.W, [2, 3]), elems=inputs_tiled)
-        #inputs_hat = inputs_tiled
-
-        # Begin: Routing algorithm ---------------------------------------------------------------------#
-        # The prior for coupling coefficient, initialized as zeros.
-        # b.shape = [None, self.num_capsule, self.input_num_capsule].
-        b = tf.zeros(shape=[K.shape(inputs_hat)[0], self.num_capsule, self.input_num_capsule])
-        output_list = []
-        assert self.routings > 0, 'The routings should be > 0.'
-        for i in range(self.routings):
-            # c.shape=[batch_size, num_capsule, input_num_capsule]
-            T_tiled = K.tile(self.T,(K.shape(inputs)[0],1,self.input_num_capsule))
-            T_tiled = 1+9*K.sigmoid(T_tiled)
-            b = b/T_tiled
-            c = tf.nn.softmax(b, dim=1)
-
-            # c.shape =  [batch_size, num_capsule, input_num_capsule]
-            # inputs_hat.shape=[None, num_capsule, input_num_capsule, dim_capsule]
-            # The first two dimensions as `batch` dimension,
-            # then matmal: [input_num_capsule] x [input_num_capsule, dim_capsule] -> [dim_capsule].
-            # outputs.shape=[None, num_capsule, dim_capsule]
-            outputs = squash(K.batch_dot(c, inputs_hat, [2, 2]))  # [None, 10, 16]
-            # output_list.append(K.expand_dims(outputs,axis=-1))
-            if i < self.routings - 1:
-                # outputs.shape =  [None, num_capsule, dim_capsule]
-                # inputs_hat.shape=[None, num_capsule, input_num_capsule, dim_capsule]
-                # The first two dimensions as `batch` dimension,
-                # then matmal: [dim_capsule] x [input_num_capsule, dim_capsule]^T -> [input_num_capsule].
-                # b.shape=[batch_size, num_capsule, input_num_capsule]
-                b += K.batch_dot(outputs, inputs_hat, [2, 3])
-                
-        # End: Routing algorithm -----------------------------------------------------------------------#
-        # return K.concatenate(output_list,-1)
-        return outputs
-
-    def compute_output_shape(self, input_shape):
-        return tuple([None, self.num_capsule, self.dim_capsule])
-        # return tuple([None, self.num_capsule, self.dim_capsule, self.routings])
-
-    def get_config(self):
-        config = {
-            'num_capsule': self.num_capsule,
-            'dim_capsule': self.dim_capsule,
-            'routings': self.routings
-        }
-        base_config = super(CapsuleLayer_T, self).get_config()
-        return dict(list(base_config.items()) + list(config.items()))
-
-
-class MatMulLayer(layers.Layer):
+class MatMulLayer(Layer):
 
     def __init__(self, output_dim, type, **kwargs):
         self.output_dim = output_dim
@@ -358,236 +137,34 @@ class MatMulLayer(layers.Layer):
         super(MatMulLayer, self).__init__(**kwargs)
 
     def build(self, input_shape):
-        
+
         # Create a trainable weight variable for this layer.
-        if self.type==1:
+        if self.type == 1:
             self.kernel = self.add_weight(name='kernel_type1',
-                                          shape=(input_shape[-1], self.output_dim),
+                                          shape=(
+                                              input_shape[-1], self.output_dim),
                                           initializer='glorot_uniform',
                                           trainable=True)
-        elif self.type==2:
+        elif self.type == 2:
             self.kernel = self.add_weight(name='kernel_type2',
-                                          shape=(input_shape[1], self.output_dim),
+                                          shape=(
+                                              input_shape[1], self.output_dim),
                                           initializer='glorot_uniform',
                                           trainable=True)
 
-        super(MatMulLayer, self).build(input_shape)  # Be sure to call this at the end
+        # Be sure to call this at the end
+        super(MatMulLayer, self).build(input_shape)
 
     def call(self, inputs):
-        if self.type==1:
-            return K.dot(inputs,self.kernel)
-        elif self.type==2:
-            new_inputs = K.permute_dimensions(inputs,(0,2,1))
-            outputs = K.dot(new_inputs,self.kernel)
-            return K.permute_dimensions(outputs,(0,2,1))
+        if self.type == 1:
+            return K.dot(inputs, self.kernel)
+        elif self.type == 2:
+            new_inputs = K.permute_dimensions(inputs, (0, 2, 1))
+            outputs = K.dot(new_inputs, self.kernel)
+            return K.permute_dimensions(outputs, (0, 2, 1))
 
     def compute_output_shape(self, input_shape):
-        if self.type==1:
+        if self.type == 1:
             return tuple([None, input_shape[1], self.output_dim])
-        elif self.type==2:
+        elif self.type == 2:
             return tuple([None, self.output_dim, input_shape[2]])
-
-
-
-class SigWLayer(layers.Layer):
-
-    def __init__(self, **kwargs):
-        super(SigWLayer, self).__init__(**kwargs)
-
-    def build(self, input_shape):
-        
-        # Create a trainable weight variable for this layer.
-        self.xw1 = self.add_weight(name='xw1',
-                                          shape=(1,),
-                                          initializer='glorot_uniform',
-                                          trainable=True)
-        self.xw2 = self.add_weight(name='xw2',
-                                          shape=(1,),
-                                          initializer='glorot_uniform',
-                                          trainable=True)
-
-
-        super(SigWLayer, self).build(input_shape)  # Be sure to call this at the end
-
-    def call(self, inputs):
-        xw1 = K.expand_dims(K.expand_dims(self.xw1,axis=-1),axis=-1)
-        xw1 = K.tile(xw1,(K.shape(inputs)[0],K.shape(inputs)[1],K.shape(inputs)[2]))
-        
-        xw2 = K.expand_dims(K.expand_dims(self.xw2,axis=-1),axis=-1)
-        xw2 = K.tile(xw2,(K.shape(inputs)[0],K.shape(inputs)[1],K.shape(inputs)[2]))
-        
-        return K.sigmoid(inputs-xw1)+K.sigmoid(inputs-xw2)
-
-    def compute_output_shape(self, input_shape):
-        return tuple(input_shape)
-        
-
-
-
-class CapsuleLayer_contrast(layers.Layer):
-    """
-    The capsule layer. It is similar to Dense layer. Dense layer has `in_num` inputs, each is a scalar, the output of the 
-    neuron from the former layer, and it has `out_num` output neurons. CapsuleLayer just expand the output of the neuron
-    from scalar to vector. So its input shape = [None, input_num_capsule, input_dim_capsule] and output shape = \
-    [None, num_capsule, dim_capsule]. For Dense Layer, input_dim_capsule = dim_capsule = 1.
-    
-    :param num_capsule: number of capsules in this layer
-    :param dim_capsule: dimension of the output vectors of the capsules in this layer
-    :param routings: number of iterations for the routing algorithm
-    """
-    def __init__(self, num_capsule, dim_capsule, routings=3,
-                 kernel_initializer='glorot_uniform',
-                 **kwargs):
-        super(CapsuleLayer_contrast, self).__init__(**kwargs)
-        self.num_capsule = num_capsule
-        self.dim_capsule = dim_capsule
-        self.routings = routings
-        self.kernel_initializer = initializers.get(kernel_initializer)
-
-    def build(self, input_shape):
-        assert len(input_shape) >= 3, "The input Tensor should have shape=[None, input_num_capsule, input_dim_capsule]"
-        self.input_num_capsule = input_shape[1]
-        self.input_dim_capsule = input_shape[2]
-
-        # Transform matrix
-        self.W = self.add_weight(shape=[self.num_capsule, self.input_num_capsule,
-                                        self.dim_capsule, self.input_dim_capsule],
-                                 initializer=self.kernel_initializer,
-                                 name='W')
-
-        self.built = True
-
-    def call(self, inputs, training=None):
-        # inputs.shape=[None, input_num_capsule, input_dim_capsule]
-        # inputs_expand.shape=[None, 1, input_num_capsule, input_dim_capsule]
-        inputs_expand = K.expand_dims(inputs, 1)
-
-        # Replicate num_capsule dimension to prepare being multiplied by W
-        # inputs_tiled.shape=[None, num_capsule, input_num_capsule, input_dim_capsule]
-        inputs_tiled = K.tile(inputs_expand, [1, self.num_capsule, 1, 1])
-
-        # Compute `inputs * W` by scanning inputs_tiled on dimension 0.
-        # x.shape=[num_capsule, input_num_capsule, input_dim_capsule]
-        # W.shape=[num_capsule, input_num_capsule, dim_capsule, input_dim_capsule]
-        # Regard the first two dimensions as `batch` dimension,
-        # then matmul: [input_dim_capsule] x [dim_capsule, input_dim_capsule]^T -> [dim_capsule].
-        # inputs_hat.shape = [None, num_capsule, input_num_capsule, dim_capsule]
-        inputs_hat = K.map_fn(lambda x: K.batch_dot(x, self.W, [2, 3]), elems=inputs_tiled)
-
-        # Begin: Routing algorithm ---------------------------------------------------------------------#
-        # The prior for coupling coefficient, initialized as zeros.
-        # b.shape = [None, self.num_capsule, self.input_num_capsule].
-        b = tf.zeros(shape=[K.shape(inputs_hat)[0], self.num_capsule, self.input_num_capsule])
-
-        assert self.routings > 0, 'The routings should be > 0.'
-        for i in range(self.routings):
-            # c.shape=[batch_size, num_capsule, input_num_capsule]
-            c = tf.nn.softmax(b, dim=1)
-
-            # c.shape =  [batch_size, num_capsule, input_num_capsule]
-            # inputs_hat.shape=[None, num_capsule, input_num_capsule, dim_capsule]
-            # The first two dimensions as `batch` dimension,
-            # then matmal: [input_num_capsule] x [input_num_capsule, dim_capsule] -> [dim_capsule].
-            # outputs.shape=[None, num_capsule, dim_capsule]
-            outputs = K.tanh(K.batch_dot(c, inputs_hat, [2, 2]))  # [None, 10, 16]
-            outputs = contrast_squash(outputs)
-            if i < self.routings - 1:
-                # outputs.shape =  [None, num_capsule, dim_capsule]
-                # inputs_hat.shape=[None, num_capsule, input_num_capsule, dim_capsule]
-                # The first two dimensions as `batch` dimension,
-                # then matmal: [dim_capsule] x [input_num_capsule, dim_capsule]^T -> [input_num_capsule].
-                # b.shape=[batch_size, num_capsule, input_num_capsule]
-                b += K.batch_dot(outputs, inputs_hat, [2, 3])
-        # End: Routing algorithm -----------------------------------------------------------------------#
-
-        return outputs
-
-    def compute_output_shape(self, input_shape):
-        return tuple([None, self.num_capsule, self.dim_capsule])
-
-    def get_config(self):
-        config = {
-            'num_capsule': self.num_capsule,
-            'dim_capsule': self.dim_capsule,
-            'routings': self.routings
-        }
-        base_config = super(CapsuleLayer_contrast, self).get_config()
-        return dict(list(base_config.items()) + list(config.items()))
-
-
-
-
-def PrimaryCap(inputs, dim_capsule, n_channels, kernel_size, strides, padding):
-    """
-    Apply Conv2D `n_channels` times and concatenate all capsules
-    :param inputs: 4D tensor, shape=[None, width, height, channels]
-    :param dim_capsule: the dim of the output vector of capsule
-    :param n_channels: the number of types of capsules
-    :return: output tensor, shape=[None, num_capsule, dim_capsule]
-    """
-    output = layers.Conv2D(filters=dim_capsule*n_channels, kernel_size=kernel_size, strides=strides, padding=padding,
-                           name='primarycap_conv2d')(inputs)
-    outputs = layers.Reshape(target_shape=[-1, dim_capsule], name='primarycap_reshape')(output)
-    return layers.Lambda(squash, name='primarycap_squash')(outputs)
-
-
-class OnlineVariancePooling(layers.Layer):
-    def __init__(self, dim_select, num_caps, dim_caps, **kwargs):
-        super(OnlineVariancePooling, self).__init__(**kwargs)
-
-        self.batch_size = 0
-        self.num_caps = num_caps
-        self.dim_caps = dim_caps
-        self.dim_select = dim_select
-
-    def call(self, inputs):
-        self.batch_size = K.shape(inputs)[0] # batch_size is dynamic shape
-        #static_shape = inputs.shape.as_list() # others are static shape
-        #self.num_caps = static_shape[1]
-        #self.dim_caps = static_shape[2]
-
-        var = K.var(inputs,axis=1)
-        reordered_feat = self.var_sort(inputs, var)
-        selected_feat = reordered_feat[:,:,0:self.dim_select]
-        return selected_feat
-
-
-    def var_sort(self, cap, var_w):
-        
-        var_w = K.expand_dims(var_w,axis=1)
-        var_w = K.tile(var_w,(1,self.num_caps,1))
-
-        sup_idx1 = K.reshape(tf.range(self.batch_size), [-1,1,1])
-        sup_idx1 = K.tile(sup_idx1, [1, self.num_caps, self.dim_caps])
-        sup_idx1_flat = K.reshape(sup_idx1,[-1])
-
-        sorted_idx = tf.contrib.framework.argsort(var_w,axis=-1,direction='DESCENDING')
-        sorted_idx_flat = K.reshape(sorted_idx,[-1])
-        
-        sup_idx2 = K.reshape(tf.range(self.num_caps), [1,-1,1])
-        sup_idx2 = K.tile(sup_idx2, [self.batch_size, 1, self.dim_caps])
-        sup_idx2_flat = K.reshape(sup_idx2,[-1])
-
-        
-        
-        final_idx = K.stack([sup_idx1_flat, sup_idx2_flat, sorted_idx_flat],axis=-1)
-        final_idx = K.reshape(final_idx,[self.batch_size, self.num_caps, self.dim_caps, 3])
-
-        reordered_cap = tf.gather_nd(cap, final_idx)
-        
-        return reordered_cap
-
-    def compute_output_shape(self, input_shape):
-        return (None, self.num_caps, self.dim_select)
-
-"""
-# The following is another way to implement primary capsule layer. This is much slower.
-# Apply Conv2D `n_channels` times and concatenate all capsules
-def PrimaryCap(inputs, dim_capsule, n_channels, kernel_size, strides, padding):
-    outputs = []
-    for _ in range(n_channels):
-        output = layers.Conv2D(filters=dim_capsule, kernel_size=kernel_size, strides=strides, padding=padding)(inputs)
-        outputs.append(layers.Reshape([output.get_shape().as_list()[1] ** 2, dim_capsule])(output))
-    outputs = layers.Concatenate(axis=1)(outputs)
-    return layers.Lambda(squash)(outputs)
-"""

--- a/lib/capsulelayers.py
+++ b/lib/capsulelayers.py
@@ -18,6 +18,8 @@ import keras.backend as K
 from keras import initializers
 from keras.layers import Layer
 
+from .utils import register_keras_custom_object
+
 
 def batch_dot(x, y, axes=None):
     """Batchwise dot product.
@@ -127,6 +129,7 @@ def squash(vectors, axis=-1):
     return scale * vectors
 
 
+@register_keras_custom_object
 class CapsuleLayer(Layer):
     """
     The capsule layer. It is similar to Dense layer. Dense layer has `in_num` inputs, each is a scalar, the output of the 
@@ -224,6 +227,7 @@ class CapsuleLayer(Layer):
         return dict(list(base_config.items()) + list(config.items()))
 
 
+@register_keras_custom_object
 class MatMulLayer(Layer):
 
     def __init__(self, output_dim, type, **kwargs):

--- a/lib/capsulelayers.py
+++ b/lib/capsulelayers.py
@@ -19,6 +19,101 @@ from keras import initializers
 from keras.layers import Layer
 
 
+def batch_dot(x, y, axes=None):
+    """Batchwise dot product.
+
+    `batch_dot` is used to compute dot product of `x` and `y` when
+    `x` and `y` are data in batch, i.e. in a shape of
+    `(batch_size, :)`.
+    `batch_dot` results in a tensor or variable with less dimensions
+    than the input. If the number of dimensions is reduced to 1,
+    we use `expand_dims` to make sure that ndim is at least 2.
+
+    # Arguments
+        x: Keras tensor or variable with `ndim >= 2`.
+        y: Keras tensor or variable with `ndim >= 2`.
+        axes: list of (or single) int with target dimensions.
+            The lengths of `axes[0]` and `axes[1]` should be the same.
+
+    # Returns
+        A tensor with shape equal to the concatenation of `x`'s shape
+        (less the dimension that was summed over) and `y`'s shape
+        (less the batch dimension and the dimension that was summed over).
+        If the final rank is 1, we reshape it to `(batch_size, 1)`.
+
+    # Examples
+        Assume `x = [[1, 2], [3, 4]]` and `y = [[5, 6], [7, 8]]`
+        `batch_dot(x, y, axes=1) = [[17], [53]]` which is the main diagonal
+        of `x.dot(y.T)`, although we never have to calculate the off-diagonal
+        elements.
+
+        Shape inference:
+        Let `x`'s shape be `(100, 20)` and `y`'s shape be `(100, 30, 20)`.
+        If `axes` is (1, 2), to find the output shape of resultant tensor,
+            loop through each dimension in `x`'s shape and `y`'s shape:
+
+        * `x.shape[0]` : 100 : append to output shape
+        * `x.shape[1]` : 20 : do not append to output shape,
+            dimension 1 of `x` has been summed over. (`dot_axes[0]` = 1)
+        * `y.shape[0]` : 100 : do not append to output shape,
+            always ignore first dimension of `y`
+        * `y.shape[1]` : 30 : append to output shape
+        * `y.shape[2]` : 20 : do not append to output shape,
+            dimension 2 of `y` has been summed over. (`dot_axes[1]` = 2)
+        `output_shape` = `(100, 30)`
+
+    ```python
+        >>> x_batch = K.ones(shape=(32, 20, 1))
+        >>> y_batch = K.ones(shape=(32, 30, 20))
+        >>> xy_batch_dot = K.batch_dot(x_batch, y_batch, axes=[1, 2])
+        >>> K.int_shape(xy_batch_dot)
+        (32, 1, 30)
+    ```
+    """
+    if isinstance(axes, int):
+        axes = (axes, axes)
+    x_ndim = K.ndim(x)
+    y_ndim = K.ndim(y)
+    if axes is None:
+        # behaves like tf.batch_matmul as default
+        axes = [x_ndim - 1, y_ndim - 2]
+    # if K.any([isinstance(a, (list, tuple)) for a in axes]):
+    #     raise ValueError('Multiple target dimensions are not supported. ' +
+    #                      'Expected: None, int, (int, int), ' +
+    #                      'Provided: ' + str(axes))
+    if x_ndim > y_ndim:
+        diff = x_ndim - y_ndim
+        y = tf.reshape(y, tf.concat([tf.shape(y), [1] * (diff)], axis=0))
+    elif y_ndim > x_ndim:
+        diff = y_ndim - x_ndim
+        x = tf.reshape(x, tf.concat([tf.shape(x), [1] * (diff)], axis=0))
+    else:
+        diff = 0
+    if K.ndim(x) == 2 and K.ndim(y) == 2:
+        if axes[0] == axes[1]:
+            out = tf.reduce_sum(tf.multiply(x, y), axes[0])
+        else:
+            out = tf.reduce_sum(tf.multiply(
+                tf.transpose(x, [1, 0]), y), axes[1])
+    else:
+        if axes is not None:
+            adj_x = None if axes[0] == K.ndim(x) - 1 else True
+            adj_y = True if axes[1] == K.ndim(y) - 1 else None
+        else:
+            adj_x = None
+            adj_y = None
+        out = tf.matmul(x, y, adjoint_a=adj_x, adjoint_b=adj_y)
+    if diff:
+        if x_ndim > y_ndim:
+            idx = x_ndim + y_ndim - 3
+        else:
+            idx = x_ndim - 1
+        out = tf.squeeze(out, list(range(idx, idx + diff)))
+    if K.ndim(out) == 1:
+        out = K.expand_dims(out, 1)
+    return out
+
+
 def squash(vectors, axis=-1):
     """
     The non-linear activation used in Capsule. It drives the length of a large vector to near 1 and small vector to 0
@@ -82,7 +177,7 @@ class CapsuleLayer(Layer):
         # Regard the first two dimensions as `batch` dimension,
         # then matmul: [input_dim_capsule] x [dim_capsule, input_dim_capsule]^T -> [dim_capsule].
         # inputs_hat.shape = [None, num_capsule, input_num_capsule, dim_capsule]
-        inputs_hat = K.map_fn(lambda x: K.batch_dot(
+        inputs_hat = K.map_fn(lambda x: batch_dot(
             x, self.W, [2, 3]), elems=inputs_tiled)
 
         # Begin: Routing algorithm ---------------------------------------------------------------------#
@@ -102,7 +197,7 @@ class CapsuleLayer(Layer):
             # then matmal: [input_num_capsule] x [input_num_capsule, dim_capsule] -> [dim_capsule].
             # outputs.shape=[None, num_capsule, dim_capsule]
             # [None, 10, 16]
-            outputs = squash(K.batch_dot(c, inputs_hat, [2, 2]))
+            outputs = squash(batch_dot(c, inputs_hat, [2, 2]))
             # output_list.append(K.expand_dims(outputs,axis=-1))
             if i < self.routings - 1:
                 # outputs.shape =  [None, num_capsule, dim_capsule]
@@ -110,7 +205,7 @@ class CapsuleLayer(Layer):
                 # The first two dimensions as `batch` dimension,
                 # then matmal: [dim_capsule] x [input_num_capsule, dim_capsule]^T -> [input_num_capsule].
                 # b.shape=[batch_size, num_capsule, input_num_capsule]
-                b += K.batch_dot(outputs, inputs_hat, [2, 3])
+                b += batch_dot(outputs, inputs_hat, [2, 3])
         # End: Routing algorithm -----------------------------------------------------------------------#
         # return K.concatenate(output_list,-1)
         return outputs

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from keras.utils import get_custom_objects
+
 
 def get_initial_weights(output_size):
     b = np.zeros((2, 3), dtype='float32')
@@ -8,3 +10,9 @@ def get_initial_weights(output_size):
     W = np.zeros((output_size, 6), dtype='float32')
     weights = [W, b.flatten()]
     return weights
+
+
+def register_keras_custom_object(cls):
+    """ A decorator to register custom layers, loss functions etc in global scope """
+    get_custom_objects()[cls.__name__] = cls
+    return cls

--- a/training_and_testing/keras_to_tf.py
+++ b/training_and_testing/keras_to_tf.py
@@ -1,0 +1,173 @@
+import re
+import os
+import sys
+import importlib
+import argparse
+sys.path.append('..')
+
+import tensorflow as tf
+from keras import backend as K
+from keras.models import load_model
+
+from tensorflow.python.framework.graph_util import convert_variables_to_constants
+
+from lib.FSANET_model import *
+
+def freeze_session(session, keep_var_names=None, output_names=None, clear_devices=True):
+
+    graph = session.graph
+    with graph.as_default():
+        freeze_var_names = list(
+            set(v.op.name for v in tf.global_variables()).difference(keep_var_names or []))
+        output_names = output_names or []
+        output_names += [v.op.name for v in tf.global_variables()]
+        # Graph -> GraphDef ProtoBuf
+        input_graph_def = graph.as_graph_def()
+        if clear_devices:
+            for node in input_graph_def.node:
+                node.device = ""
+        frozen_graph = convert_variables_to_constants(session, input_graph_def,
+                                                      output_names, freeze_var_names)
+        return frozen_graph
+
+
+def class_for_name(module_name, class_name):
+    # load the module, will raise ImportError if module cannot be loaded
+    m = importlib.import_module(module_name)
+    # get the class, will raise AttributeError if class cannot be found
+    c = getattr(m, class_name)
+    return c
+
+
+def build_model_class_from_name(model_name):
+
+    is_var_model = "var" in model_name
+    is_noS_model = "noS" in model_name
+    is_capsule_model = "capsule" in model_name
+    is_netvlad_model = "netvlad" in model_name
+    is_metric_model = "metric" in model_name
+
+    model_class_name = f"FSA_net_"
+    if is_capsule_model:
+        if is_var_model:
+            model_class_name = model_class_name + "Var_Capsule"
+        elif is_noS_model:
+            model_class_name = model_class_name + "noS_Capsule"
+        else:
+            model_class_name = model_class_name + "Capsule"
+
+    if is_netvlad_model:
+        if is_var_model:
+            model_class_name = model_class_name + "Var_NetVLAD"
+        elif is_noS_model:
+            model_class_name = model_class_name + "noS_NetVLAD"
+        else:
+            model_class_name = model_class_name + "NetVLAD"
+
+    if is_metric_model:
+        if is_var_model:
+            model_class_name = model_class_name + "Var_Metric"
+        elif is_noS_model:
+            model_class_name = model_class_name + "noS_Metric"
+        else:
+            model_class_name = model_class_name + "Metric"
+
+    return model_class_name
+
+
+def create_model(model_name, model_class_name):
+    """ Since the archived models have lambda layers in them
+    we need to first load them using the new model definitions.
+    The load will be successful as I have preserved the names of the trainable layers.
+    After that we do need to save it so that it has custom layers and then we load it back again """
+
+    # we will use the name of the directory to dynamically create the corresponding
+    # class and the hyper-parameters (which thankfully are encoded in the name of the directory)
+
+    model_cls = class_for_name("lib", model_class_name)
+
+    hparams_start_loc = re.search("\d", model_name).start()
+    hprams_str = model_name[hparams_start_loc:]
+
+    # now split it by '_' and cast it as int
+    hparams = [int(d) for d in hprams_str.split('_')]
+
+    # static params
+    stage_num = [3, 3, 3]
+    lambda_d = 1
+    num_classes = 3
+    image_size = 64
+
+    # now create the model object
+    model_obj = model_cls(image_size, num_classes,
+                          stage_num, lambda_d, hparams)()
+
+    model_obj.count_params()
+    model_obj.summary()
+
+    return model_obj
+
+
+def parse_arguments(argv):
+    """ Parse the arguments """
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        '--trained-model-dir-path',
+        required=True,
+        type=str,
+        help='The directory that contains the pre-trained model')
+
+    parser.add_argument(
+        '--output-dir-path',
+        required=True,
+        type=str,
+        help='The directory that would contain the converted models')
+
+    return parser.parse_args(argv)
+
+
+def main(args):
+
+    model_name = os.path.basename(args.trained_model_dir_path)
+
+    # convert existing model with lambda layers to
+    # new model with custom layers
+    model_cls_name = build_model_class_from_name(model_name)
+
+    model_obj = create_model(model_name, model_cls_name)
+
+    # we now save it in the temp folder
+    # this version will now be saved with the custom layer information
+    # serialized
+    converted_keras_model_dir = os.path.join(args.output_dir_path,
+                                             "converted-models", "keras")
+
+    os.makedirs(converted_keras_model_dir, exist_ok=True)
+
+    keras_model_path = os.path.join(
+        converted_keras_model_dir, model_name) + ".hd5"
+
+    model_obj.save(keras_model_path)
+
+    K.set_learning_phase(0)
+
+    model = load_model(keras_model_path)
+
+    print(f"Model inputs information - {model.inputs}")
+    print(f"Model outputs information - {model.outputs}")
+
+    # freez the graph
+    frozen_graph = freeze_session(K.get_session(),
+                                  output_names=[out.op.name for out in model.outputs])
+
+    tf_dir_path = os.path.join(args.output_dir_path, "converted-models", "tf")
+    os.makedirs(tf_dir_path, exist_ok=True)
+
+    # write the graph
+    tf.io.write_graph(frozen_graph, tf_dir_path,
+                         f"{model_name}.pb", as_text=False)
+
+
+if __name__ == '__main__':
+    main(parse_arguments(sys.argv[1:]))


### PR DESCRIPTION
Hi @shamangary 

As I mentioned earlier, usage of Lambda layers create issues to do conversions and require python as the run time. My main goal was to be able to convert the models to tensorflow. 

Fortunately I managed to write the custom layers and conversion process in such a way that **your pre-trained models can still be used & imported**. This also helps in making sure that I am not introducing the bugs. I have ran the test script and validated that there is no change in the accuracy of various models. 

## Difficult part:

To support latest keras, I had to import the batch_dot from previous versions. Capsule layer uses batch_dot which in latest keras complains. Now I do not know Capsule networks in depth so for now I have place the batch_dot implementation along side. The correct way to do it would be to use a new implemention of Capsule network. I indeed tried it but the way the new implementation (from keras-contrib) works is differen from what you have. Usage of new capsule implementation will lead to not be able to use your pretrained models therefore I added the compliant batch_dot implementation. 

## New feature thanks to custom layers
Finally there is a script in training_and_testing folder that is now capable of converting to tensroflow pb model. From this point conversion to tensorRT, onnx etc should be simple. 

## Potential merge issue
When I started the branch I did not see your revision where you changed 8*8 to self.map_x_y*self.map_x_y. I have added that change however github is complaining that the pull request can not be merged. I hope it is not a problem.

Let me know if you have questions. 

Regards
Kapil

