### PR TITLE
Update run_fsanet_test.sh

### DIFF
--- a/training_and_testing/run_fsanet_test.sh
+++ b/training_and_testing/run_fsanet_test.sh
@@ -1,4 +1,4 @@
-KERAS_BACKEND=tensorflow python FSANET_test.py --model_type 0
+KERAS_BACKEND=tensorflow python FSANET_test.py --model_type 1  --use_pretrained
 
 
 KERAS_BACKEND=tensorflow python FSANET_mix_test.py --model_type 0


### PR DESCRIPTION
If we set --model_type 0, it called ssrnet_ori_mt folder. However, this folder doesn't exist, instead set to 1

We need to specify the tag --use_pretrained to load the weights correctly.